### PR TITLE
Need a timestamp function to return ISO 8601 compatible strings

### DIFF
--- a/docs/timestamps.rst
+++ b/docs/timestamps.rst
@@ -73,3 +73,12 @@ High-precision timestamps
    ``false``.  The ``_utc`` variant assumes that *ts* represents a UTC
    time, whereas teh ``_local`` variant assumes that it represents a
    time in the local time zone.
+
+
+.. function:: bool cork_timestamp_format_iso8601(const cork timestamp ts, char \*buf, size_t size)
+
+   Fills in *buf* with the string representation of the given timestamp,
+   according to the ISO 8601 compatible format ``YYYY-MM-DDThh:mm:ssZ``.
+   *size* must be the size (in bytes) of *buf*.  If we can't format the
+   timestamp for any reason, we return ``false``.  We assume that *ts*
+   represents a UTC time.

--- a/docs/timestamps.rst
+++ b/docs/timestamps.rst
@@ -70,15 +70,15 @@ High-precision timestamps
    according to *fmt*, which should be a format string compatible with
    the POSIX ``strftime`` function.  *size* must be the size (in bytes)
    of *buf*.  If we can't format the timestamp for any reason, we return
-   ``false``.  The ``_utc`` variant assumes that *ts* represents a UTC
-   time, whereas teh ``_local`` variant assumes that it represents a
-   time in the local time zone.
+   ``false``.  We assume *ts* represents a UTC time in both functions.
 
 
-.. function:: bool cork_timestamp_format_iso8601(const cork timestamp ts, char \*buf, size_t size)
+.. function:: bool cork_timestamp_format_iso8601_utc(const cork timestamp ts, char \*buf, size_t size)
+              bool cork_timestamp_format_iso8601_local(const cork timestamp ts, char \*buf, size_t size)
 
    Fills in *buf* with the string representation of the given timestamp,
-   according to the ISO 8601 compatible format ``YYYY-MM-DDThh:mm:ssZ``.
-   *size* must be the size (in bytes) of *buf*.  If we can't format the
-   timestamp for any reason, we return ``false``.  We assume that *ts*
-   represents a UTC time.
+   according to the ISO 8601 compatible format ``YYYY-MM-DDThh:mm:ssZ``
+   for UTC time and ``YYYY-MM-DDThh:mm:zz+/-hhmm`` for times in the local
+   time zone. *size* must be the size (in bytes) of *buf*.  If we can't
+   format the timestamp for any reason, we return ``false``.  We assume
+   that *ts* represents a UTC time in both functions.

--- a/include/libcork/core/timestamp.h
+++ b/include/libcork/core/timestamp.h
@@ -70,5 +70,7 @@ bool
 cork_timestamp_format_local(const cork_timestamp ts, const char *format,
                             char *buf, size_t size);
 
+bool
+cork_timestamp_format_iso8601(const cork_timestamp ts, char *buf, size_t size);
 
 #endif /* LIBCORK_CORE_TIMESTAMP_H */

--- a/include/libcork/core/timestamp.h
+++ b/include/libcork/core/timestamp.h
@@ -71,6 +71,11 @@ cork_timestamp_format_local(const cork_timestamp ts, const char *format,
                             char *buf, size_t size);
 
 bool
-cork_timestamp_format_iso8601(const cork_timestamp ts, char *buf, size_t size);
+cork_timestamp_format_iso8601_utc(const cork_timestamp ts, char *buf,
+                                  size_t size);
+
+bool
+cork_timestamp_format_iso8601_local(const cork_timestamp ts, char *buf,
+                                    size_t size);
 
 #endif /* LIBCORK_CORE_TIMESTAMP_H */

--- a/src/libcork/core/timestamp.c
+++ b/src/libcork/core/timestamp.c
@@ -51,8 +51,8 @@ cork_timestamp_format_local(const cork_timestamp ts,
 }
 
 bool
-cork_timestamp_format_iso8601(const cork_timestamp ts,
-                              char *buf, size_t size)
+cork_timestamp_format_iso8601_utc(const cork_timestamp ts,
+                                  char *buf, size_t size)
 {
     time_t  clock;
     struct tm  tm;
@@ -60,4 +60,16 @@ cork_timestamp_format_iso8601(const cork_timestamp ts,
     clock = cork_timestamp_sec(ts);
     gmtime_r(&clock, &tm);
     return strftime(buf, size, "%FT%H:%M:%SZ", &tm) > 0;
+}
+
+bool
+cork_timestamp_format_iso8601_local(const cork_timestamp ts,
+                                    char *buf, size_t size)
+{
+    time_t  clock;
+    struct tm  tm;
+
+    clock = cork_timestamp_sec(ts);
+    localtime_r(&clock, &tm);
+    return strftime(buf, size, "%FT%H:%M:%S%z", &tm) > 0;
 }

--- a/src/libcork/core/timestamp.c
+++ b/src/libcork/core/timestamp.c
@@ -49,3 +49,15 @@ cork_timestamp_format_local(const cork_timestamp ts,
     localtime_r(&clock, &tm);
     return strftime(buf, size, format, &tm) > 0;
 }
+
+bool
+cork_timestamp_format_iso8601(const cork_timestamp ts,
+                              char *buf, size_t size)
+{
+    time_t  clock;
+    struct tm  tm;
+
+    clock = cork_timestamp_sec(ts);
+    gmtime_r(&clock, &tm);
+    return strftime(buf, size, "%FT%H:%M:%SZ", &tm) > 0;
+}

--- a/tests/test-core.c
+++ b/tests/test-core.c
@@ -586,12 +586,15 @@ START_TEST(test_timestamp)
 
     static const uint32_t  TEST_TIME_1 = 700000000;
     static const char  *FORMATTED_TIME_1 = "1992-03-07 20:26:40";
+    static const char  *FORMATTED_ISO8601_TIME_1 = "1992-03-07T20:26:40Z";
 
     static const uint32_t  TEST_TIME_2 = 1200000000;
     static const char  *FORMATTED_TIME_2 = "2008-01-10 21:20:00";
+    static const char  *FORMATTED_ISO8601_TIME_2 = "2008-01-10T21:20:00Z";
 
     static const uint32_t  TEST_TIME_3 = 1305180745;
     static const char  *FORMATTED_TIME_3 = "2011-05-12 06:12:25";
+    static const char  *FORMATTED_ISO8601_TIME_3 = "2011-05-12T06:12:25Z";
 
     cork_timestamp  ts;
 
@@ -609,6 +612,13 @@ START_TEST(test_timestamp)
                 "Unexpected formatted time (got %s, expected %s)", \
                 buf, expected);
 
+#define test_iso8601_format(expected) \
+    fail_unless(cork_timestamp_format_iso8601(ts, buf, size), \
+                "Cannot format ISO 8601 timestamp"); \
+    fail_unless(strcmp(buf, expected) == 0, \
+                "Unexpected formatted ISO 8601 time (got %s, expected %s)", \
+                buf, expected);
+
     cork_timestamp_init_sec(&ts, TEST_TIME_1);
     test(sec, TEST_TIME_1);
     test(gsec, 0);
@@ -616,6 +626,7 @@ START_TEST(test_timestamp)
     test(usec, 0);
     test(nsec, 0);
     test_format(FORMATTED_TIME_1);
+    test_iso8601_format(FORMATTED_ISO8601_TIME_1);
 
     cork_timestamp_init_sec(&ts, TEST_TIME_2);
     test(sec, TEST_TIME_2);
@@ -624,6 +635,7 @@ START_TEST(test_timestamp)
     test(usec, 0);
     test(nsec, 0);
     test_format(FORMATTED_TIME_2);
+    test_iso8601_format(FORMATTED_ISO8601_TIME_2);
 
     cork_timestamp_init_sec(&ts, TEST_TIME_3);
     test(sec, TEST_TIME_3);
@@ -632,6 +644,7 @@ START_TEST(test_timestamp)
     test(usec, 0);
     test(nsec, 0);
     test_format(FORMATTED_TIME_3);
+    test_iso8601_format(FORMATTED_ISO8601_TIME_3);
 
     cork_timestamp_init_gsec(&ts, TEST_TIME_1, 1 << 30);
     test(sec, TEST_TIME_1);

--- a/tests/test-core.c
+++ b/tests/test-core.c
@@ -612,8 +612,8 @@ START_TEST(test_timestamp)
                 "Unexpected formatted time (got %s, expected %s)", \
                 buf, expected);
 
-#define test_iso8601_format(expected) \
-    fail_unless(cork_timestamp_format_iso8601(ts, buf, size), \
+#define test_iso8601_utc_format(expected) \
+    fail_unless(cork_timestamp_format_iso8601_utc(ts, buf, size), \
                 "Cannot format ISO 8601 timestamp"); \
     fail_unless(strcmp(buf, expected) == 0, \
                 "Unexpected formatted ISO 8601 time (got %s, expected %s)", \
@@ -626,7 +626,7 @@ START_TEST(test_timestamp)
     test(usec, 0);
     test(nsec, 0);
     test_format(FORMATTED_TIME_1);
-    test_iso8601_format(FORMATTED_ISO8601_TIME_1);
+    test_iso8601_utc_format(FORMATTED_ISO8601_TIME_1);
 
     cork_timestamp_init_sec(&ts, TEST_TIME_2);
     test(sec, TEST_TIME_2);
@@ -635,7 +635,7 @@ START_TEST(test_timestamp)
     test(usec, 0);
     test(nsec, 0);
     test_format(FORMATTED_TIME_2);
-    test_iso8601_format(FORMATTED_ISO8601_TIME_2);
+    test_iso8601_utc_format(FORMATTED_ISO8601_TIME_2);
 
     cork_timestamp_init_sec(&ts, TEST_TIME_3);
     test(sec, TEST_TIME_3);
@@ -644,7 +644,7 @@ START_TEST(test_timestamp)
     test(usec, 0);
     test(nsec, 0);
     test_format(FORMATTED_TIME_3);
-    test_iso8601_format(FORMATTED_ISO8601_TIME_3);
+    test_iso8601_utc_format(FORMATTED_ISO8601_TIME_3);
 
     cork_timestamp_init_gsec(&ts, TEST_TIME_1, 1 << 30);
     test(sec, TEST_TIME_1);


### PR DESCRIPTION
Many clients rely on ISO 8601 compatible string representations of time because the sort correctly, there is no space encoding incompatibilities across platforms, and most time/date libraries contain 8601 parsers.