### PR TITLE
Support for cork_bitsets allocated on the stack

### DIFF
--- a/docs/old/bitset.rst
+++ b/docs/old/bitset.rst
@@ -28,14 +28,29 @@ bitset to exhaust the available memory.
       you the number of bits in total, on or off.)
 
 
+.. function:: void cork_bitset_init(struct cork_bitset \*set)
+
+   Initialize a new bitset instance that you've allocated yourself
+   (usually on the stack).  All bits will be initialized to ``0``.
+
 .. function:: struct cork_bitset \*cork_bitset_new(size_t bit_count)
 
-   Create a new bitset with enough space to store the given number of bits.  All
-   bits will be initialized to ``0``.
+   Create a new bitset with enough space to store the given number of bits.
+   All bits will be initialized to ``0``.
+
+.. function:: void cork_bitset_done(struct cork_bitset \*set)
+
+   Finalize a bitset, freeing any set content that it contains.  This
+   function should only be used for bitsets that you allocated yourself,
+   and initialized using :c:func:`cork_bitset_init()`.  You must **not** use
+   this function to free a bitset allocated using :c:func:`cork_bitset_new()`.
 
 .. function:: void cork_bitset_free(struct cork_bitset \*set)
 
-   Free a bitset.
+   Finalize and deallocate a bitset, freeing any set content that it
+   contains.  This function should only be used for bitsets allocated
+   using :c:func:`cork_bitset_new()`.  You must **not** use this
+   function to free a bitset initialized using :c:func:`cork_bitset_init()`.
 
 .. function:: bool cork_bitset_get(struct cork_bitset \*set, size_t index)
 

--- a/docs/old/buffer.rst
+++ b/docs/old/buffer.rst
@@ -69,7 +69,7 @@ automatically resizing the underlying buffer when necessary.
    function should only be used for buffers that you allocated yourself,
    and initialized using :c:func:`cork_buffer_init()` or
    :c:func:`CORK_BUFFER_INIT()`.  You must **not** use this function to
-   free a buffer allocated using :c:func:`cork_buffer_free()`.
+   free a buffer allocated using :c:func:`cork_buffer_new()`.
 
 .. function:: void cork_buffer_free(struct cork_buffer \*buffer)
 

--- a/include/libcork/ds/bitset.h
+++ b/include/libcork/ds/bitset.h
@@ -29,7 +29,13 @@ CORK_API struct cork_bitset *
 cork_bitset_new(size_t bit_count);
 
 CORK_API void
+cork_bitset_init(struct cork_bitset *set, size_t bit_count);
+
+CORK_API void
 cork_bitset_free(struct cork_bitset *set);
+
+CORK_API void
+cork_bitset_done(struct cork_bitset *set);
 
 CORK_API void
 cork_bitset_clear(struct cork_bitset *set);

--- a/src/libcork/ds/bitset.c
+++ b/src/libcork/ds/bitset.c
@@ -25,21 +25,33 @@ bytes_needed(size_t bit_count)
     return bytes_needed;
 }
 
-struct cork_bitset *
-cork_bitset_new(size_t bit_count)
+void
+cork_bitset_init(struct cork_bitset *set, size_t bit_count)
 {
-    struct cork_bitset  *set = cork_new(struct cork_bitset);
     set->bit_count = bit_count;
     set->byte_count = bytes_needed(bit_count);
     set->bits = cork_malloc(set->byte_count);
     memset(set->bits, 0, set->byte_count);
+}
+
+struct cork_bitset *
+cork_bitset_new(size_t bit_count)
+{
+    struct cork_bitset  *set = cork_new(struct cork_bitset);
+    cork_bitset_init(set, bit_count);
     return set;
+}
+
+void
+cork_bitset_done(struct cork_bitset *set)
+{
+    cork_free(set->bits, set->byte_count);
 }
 
 void
 cork_bitset_free(struct cork_bitset *set)
 {
-    cork_free(set->bits, set->byte_count);
+    cork_bitset_done(set);
     cork_delete(struct cork_bitset, set);
 }
 

--- a/tests/test-bitset.c
+++ b/tests/test-bitset.c
@@ -27,19 +27,31 @@ static void
 test_bitset_of_size(size_t bit_count)
 {
     size_t  i;
-    struct cork_bitset  *set = cork_bitset_new(bit_count);
+    struct cork_bitset  *set1 = cork_bitset_new(bit_count);
+    struct cork_bitset set2;
 
     for (i = 0; i < bit_count; i++) {
-        cork_bitset_set(set, i, true);
-        fail_unless(cork_bitset_get(set, i), "Unexpected value for bit %zu", i);
+        cork_bitset_set(set1, i, true);
+        fail_unless(cork_bitset_get(set1, i), "Unexpected value for bit %zu", i);
     }
 
     for (i = 0; i < bit_count; i++) {
-        cork_bitset_set(set, i, false);
-        fail_if(cork_bitset_get(set, i), "Unexpected value for bit %zu", i);
+        cork_bitset_set(set1, i, false);
+        fail_if(cork_bitset_get(set1, i), "Unexpected value for bit %zu", i);
+    }
+    cork_bitset_free(set1);
+
+    cork_bitset_init(&set2, bit_count);
+    for (i = 0; i < bit_count; i++) {
+        cork_bitset_set(&set2, i, true);
+        fail_unless(cork_bitset_get(&set2, i), "Unexpected value for bit %zu", i);
     }
 
-    cork_bitset_free(set);
+    for (i = 0; i < bit_count; i++) {
+        cork_bitset_set(&set2, i, false);
+        fail_if(cork_bitset_get(&set2, i), "Unexpected value for bit %zu", i);
+    }
+    cork_bitset_done(&set2);
 }
 
 START_TEST(test_bitset)


### PR DESCRIPTION
We need to support instances of `cork_bitset` allocated on the stack with `_init()` and `_done()` functions.  This makes them similar to the interface for `cork_buffers`.