### PR TITLE
Fix use-after-free when entries deleted during map operation

### DIFF
--- a/src/libcork/ds/hash-table.c
+++ b/src/libcork/ds/hash-table.c
@@ -614,6 +614,7 @@ cork_hash_table_map(struct cork_hash_table *table, void *user_data,
         } else if (result == CORK_HASH_TABLE_MAP_DELETE) {
             DEBUG("      Delete requested");
             cork_dllist_remove(curr);
+            cork_dllist_remove(&entry->in_bucket);
             table->entry_count--;
             cork_hash_table_free_entry(table, entry);
         }


### PR DESCRIPTION
Valgrind found this issue. During the map operation, you can specify that the entry you just mapped over be deleted. However, in doing so, the upstream code was removing it from only one of the lists it was on (`insertion_order`). When you then went to search the table the next time, it would iterate the *other* list (`in_bucket`), causing a use-after-free issue. This patch removes it from both lists at the time of deletion, preventing the issue.