### PR TITLE
Library version API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,26 @@ endif(VERSION_RESULT)
 
 string(REGEX REPLACE "-dev.*" "-dev" BASE_VERSION "${VERSION}")
 
+if(BASE_VERSION MATCHES "^([0-9]+)\\.([0-9]+)\\.([0-9]+)(-dev)?$")
+    set(VERSION_MAJOR "${CMAKE_MATCH_1}")
+    set(VERSION_MINOR "${CMAKE_MATCH_2}")
+    set(VERSION_PATCH "${CMAKE_MATCH_3}")
+else(BASE_VERSION MATCHES "^([0-9]+)\\.([0-9]+)\\.([0-9]+)(-dev)?$")
+    message(FATAL_ERROR "Invalid version number: ${VERSION}")
+endif(BASE_VERSION MATCHES "^([0-9]+)\\.([0-9]+)\\.([0-9]+)(-dev)?$")
+
+execute_process(
+    COMMAND git rev-parse HEAD
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    RESULT_VARIABLE GIT_SHA1_RESULT
+    OUTPUT_VARIABLE GIT_SHA1
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+if(GIT_SHA1_RESULT)
+    message(FATAL_ERROR
+            "Cannot determine git commit: " ${GIT_SHA1_RESULT})
+endif(GIT_SHA1_RESULT)
+
 find_package(PkgConfig)
 
 #-----------------------------------------------------------------------

--- a/docs/old/_static/docco-sphinx.css
+++ b/docs/old/_static/docco-sphinx.css
@@ -187,6 +187,11 @@ div.seealso {
     border: 1px solid #ff6;
 }
 
+div.tip {
+    background-color: #e4e4ff;
+    border: 1px solid #ccc;
+}
+
 div.topic {
     background-color: #eee;
 }

--- a/docs/old/config.rst
+++ b/docs/old/config.rst
@@ -44,6 +44,24 @@ autodetection logic.  Other libcork modules will use the values of these
 macros to choose among the possible implementations.
 
 
+.. macro:: CORK_CONFIG_VERSION_MAJOR
+           CORK_CONFIG_VERSION_MINOR
+           CORK_CONFIG_VERSION_PATCH
+
+   The libcork library version, with each part of the version number separated
+   out into separate macros.
+
+
+.. macro:: CORK_CONFIG_VERSION_STRING
+
+   The libcork library version, encoded as a single string.
+
+
+.. macro:: CORK_CONFIG_REVISION
+
+   The git SHA-1 commit identifier of the libcork version that you're using.
+
+
 .. macro:: CORK_CONFIG_ARCH_X86
            CORK_CONFIG_ARCH_X64
            CORK_CONFIG_ARCH_PPC

--- a/docs/old/index.rst
+++ b/docs/old/index.rst
@@ -35,6 +35,7 @@ Contents
    :maxdepth: 2
 
    config
+   versions
    visibility
    basic-types
    byte-order

--- a/docs/old/versions.rst
+++ b/docs/old/versions.rst
@@ -1,0 +1,74 @@
+.. _versions:
+
+***************
+Library version
+***************
+
+.. highlight:: c
+
+::
+
+  #include <libcork/core.h>
+
+The macros and functions in this section let you determine the version of the
+libcork library at compile-time and runtime, and make it easier for you to
+define similar macros and functions in your own libraries.
+
+
+libcork version
+---------------
+
+.. macro:: CORK_VERSION
+
+   The libcork library version, encoded as a single number as follows::
+
+       (major * 1000000) + (minor * 1000) + patch
+
+   For instance, version 1.2.10 would be encoded as 1002010.
+
+.. macro:: CORK_VERSION_MAJOR
+           CORK_VERSION_MINOR
+           CORK_VERSION_PATCH
+
+   The libcork library version, with each part of the version number separated
+   out into separate macros.
+
+
+.. function:: const char \*cork_version_string(void)
+              const char \*cork_revision_string(void)
+
+   Return the libcork library version or revision as a string.  The *version* is
+   the simple three-part version number (``major:minor:patch``).  The
+   *revision* is an opaque string that identifies the specific revision in
+   libcork's code history.  (Right now, this is a SHA-1 git commit identifier.)
+
+
+.. tip:: Compile-time vs runtime
+
+   There's an important difference between the :c:macro:`CORK_VERSION` macro and
+   :c:func:`cork_version_string` function, even though they seemingly return the
+   same information.
+
+   The macro version be evaluated by the preprocessor, and so it will return the
+   version that was available *when your code was compiled*.  If you later
+   install a newer (but backwards-compatible) version of libcork, any code that
+   called the macro will still have the original version, and not the new
+   version.
+
+   The function version, on the other hand, calculates the version information
+   *at runtime*, when the function is actually called.  That means that the
+   function result will always give you the current installed libcork version,
+   even as newer versions are installed on the system.
+
+
+Constructing version information
+--------------------------------
+
+If you're writing a library that uses libcork, it's a good idea to provide your
+own version information, similar to how libcork does.
+
+
+.. function:: CORK_MAKE_VERSION(major, minor, patch)
+
+   Assemble a ``major.minor.patch`` version into a single number, using the same
+   pattern as :c:macro:`CORK_VERSION`.

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -1,12 +1,20 @@
 # -*- coding: utf-8 -*-
 # ----------------------------------------------------------------------
-# Copyright © 2011, RedJack, LLC.
+# Copyright © 2011-2015, RedJack, LLC.
 # All rights reserved.
 #
-# Please see the COPYING file in this distribution for license
-# details.
+# Please see the COPYING file in this distribution for license details.
 # ----------------------------------------------------------------------
+
+configure_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/libcork/config/version.h.in
+    ${CMAKE_CURRENT_BINARY_DIR}/libcork/config/version.h
+    ESCAPE_QUOTES @ONLY
+)
 
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/
     DESTINATION include
     FILES_MATCHING PATTERN "*.h")
+
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libcork/config/version.h
+        DESTINATION include/libcork/config)

--- a/include/libcork/config/config.h
+++ b/include/libcork/config/config.h
@@ -1,10 +1,9 @@
 /* -*- coding: utf-8 -*-
  * ----------------------------------------------------------------------
- * Copyright © 2011-2013, RedJack, LLC.
+ * Copyright © 2011-2015, RedJack, LLC.
  * All rights reserved.
  *
- * Please see the COPYING file in this distribution for license
- * details.
+ * Please see the COPYING file in this distribution for license details.
  * ----------------------------------------------------------------------
  */
 
@@ -26,6 +25,11 @@
 
 #else
 /* Otherwise autodetect! */
+
+
+/**** VERSION ****/
+
+#include <libcork/config/version.h>
 
 
 /**** ARCHITECTURES ****/

--- a/include/libcork/config/version.h.in
+++ b/include/libcork/config/version.h.in
@@ -1,0 +1,25 @@
+/* -*- coding: utf-8 -*-
+ * ----------------------------------------------------------------------
+ * Copyright © 2015, RedJack, LLC.
+ * All rights reserved.
+ *
+ * Please see the COPYING file in this distribution for license details.
+ * ----------------------------------------------------------------------
+ */
+
+#ifndef LIBCORK_CONFIG_VERSION_H
+#define LIBCORK_CONFIG_VERSION_H
+
+
+/*-----------------------------------------------------------------------
+ * Library version
+ */
+
+#define CORK_CONFIG_VERSION_MAJOR   @VERSION_MAJOR@
+#define CORK_CONFIG_VERSION_MINOR   @VERSION_MINOR@
+#define CORK_CONFIG_VERSION_PATCH   @VERSION_PATCH@
+#define CORK_CONFIG_VERSION_STRING  "@VERSION@"
+#define CORK_CONFIG_REVISION        "@GIT_SHA1@"
+
+
+#endif /* LIBCORK_CONFIG_VERSION_H */

--- a/include/libcork/core/api.h
+++ b/include/libcork/core/api.h
@@ -1,17 +1,22 @@
 /* -*- coding: utf-8 -*-
  * ----------------------------------------------------------------------
- * Copyright © 2012, RedJack, LLC.
+ * Copyright © 2012-2015, RedJack, LLC.
  * All rights reserved.
  *
- * Please see the COPYING file in this distribution for license
- * details.
+ * Please see the COPYING file in this distribution for license details.
  * ----------------------------------------------------------------------
  */
 
 #ifndef LIBCORK_CORE_API_H
 #define LIBCORK_CORE_API_H
 
+#include <libcork/config.h>
 #include <libcork/core/attributes.h>
+
+
+/*-----------------------------------------------------------------------
+ * Calling conventions
+ */
 
 /* If you're using libcork as a shared library, you don't need to do anything
  * special; the following will automatically set things up so that libcork's
@@ -21,5 +26,31 @@
 #if !defined(CORK_API)
 #define CORK_API  CORK_IMPORT
 #endif
+
+
+/*-----------------------------------------------------------------------
+ * Library version
+ */
+
+#define CORK_VERSION_MAJOR  CORK_CONFIG_VERSION_MAJOR
+#define CORK_VERSION_MINOR  CORK_CONFIG_VERSION_MINOR
+#define CORK_VERSION_PATCH  CORK_CONFIG_VERSION_PATCH
+
+#define CORK_MAKE_VERSION(major, minor, patch) \
+    ((major * 1000000) + (minor * 1000) + patch)
+
+#define CORK_VERSION  \
+    CORK_MAKE_VERSION(CORK_VERSION_MAJOR, \
+                      CORK_VERSION_MINOR, \
+                      CORK_VERSION_PATCH)
+
+CORK_API const char *
+cork_version_string(void)
+    CORK_ATTR_CONST;
+
+CORK_API const char *
+cork_revision_string(void)
+    CORK_ATTR_CONST;
+
 
 #endif /* LIBCORK_CORE_API_H */

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,7 +6,8 @@
 # Please see the COPYING file in this distribution for license details.
 # ----------------------------------------------------------------------
 
-include_directories(../include)
+include_directories(${CMAKE_SOURCE_DIR}/include)
+include_directories(${CMAKE_BINARY_DIR}/include)
 
 #-----------------------------------------------------------------------
 # Build the library
@@ -21,6 +22,7 @@ set(LIBCORK_SRC
     libcork/core/mempool.c
     libcork/core/timestamp.c
     libcork/core/u128.c
+    libcork/core/version.c
     libcork/ds/array.c
     libcork/ds/bitset.c
     libcork/ds/buffer.c

--- a/src/cork-hash/cork-hash.c
+++ b/src/cork-hash/cork-hash.c
@@ -1,10 +1,9 @@
 /* -*- coding: utf-8 -*-
  * ----------------------------------------------------------------------
- * Copyright © 2012, RedJack, LLC.
+ * Copyright © 2012-2015, RedJack, LLC.
  * All rights reserved.
  *
- * Please see the COPYING file in this distribution for license
- * details.
+ * Please see the COPYING file in this distribution for license details.
  * ----------------------------------------------------------------------
  */
 
@@ -24,10 +23,13 @@ enum cork_hash_type {
 static enum cork_hash_type  type = CORK_HASH_STABLE;
 static const char  *string = NULL;
 
+#define OPT_VERSION 1000
+
 static struct option  opts[] = {
     { "big", no_argument, NULL, 'b' },
     { "fastest", no_argument, NULL, 'f' },
     { "stable", no_argument, NULL, 's' },
+    { "version", no_argument, NULL, OPT_VERSION },
     { NULL, 0, NULL, 0 }
 };
 
@@ -41,6 +43,18 @@ usage(void)
             "  -b, --big\n"
             "  -f, --fastest\n"
             "  -s, --stable\n");
+}
+
+static void
+print_version(void)
+{
+    const char  *version = cork_version_string();
+    const char  *revision = cork_revision_string();
+
+    printf("cork-hash %s\n", version);
+    if (strcmp(version, revision) != 0) {
+        printf("Revision %s\n", revision);
+    }
 }
 
 static void
@@ -58,6 +72,9 @@ parse_options(int argc, char **argv)
             case 's':
                 type = CORK_HASH_STABLE;
                 break;
+            case OPT_VERSION:
+                print_version();
+                exit(EXIT_SUCCESS);
             default:
                 usage();
                 exit(EXIT_FAILURE);

--- a/src/libcork/core/version.c
+++ b/src/libcork/core/version.c
@@ -1,0 +1,28 @@
+/* -*- coding: utf-8 -*-
+ * ----------------------------------------------------------------------
+ * Copyright © 2015, RedJack, LLC.
+ * All rights reserved.
+ *
+ * Please see the COPYING file in this distribution for license details.
+ * ----------------------------------------------------------------------
+ */
+
+#include "libcork/config.h"
+#include "libcork/core/api.h"
+
+
+/*-----------------------------------------------------------------------
+ * Library version
+ */
+
+const char *
+cork_version_string(void)
+{
+    return CORK_CONFIG_VERSION_STRING;
+}
+
+const char *
+cork_revision_string(void)
+{
+    return CORK_CONFIG_REVISION;
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6,7 +6,8 @@
 # Please see the COPYING file in this distribution for license details.
 # ----------------------------------------------------------------------
 
-include_directories(../include)
+include_directories(${CMAKE_SOURCE_DIR}/include)
+include_directories(${CMAKE_BINARY_DIR}/include)
 link_directories(${CMAKE_CURRENT_BINARY_DIR}/../src)
 
 #-----------------------------------------------------------------------


### PR DESCRIPTION
We now provide access to the libcork version number using both compile-time macros and runtime functions.  Right now only the macros support comparison, using the common `(major*1000000 + minor*1000 + patch)` pattern.