### PR TITLE
Use cmake helper macros

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,11 @@ set(RELEASE_DATE 2015-03-12)
 project(${PROJECT_NAME})
 enable_testing()
 
+set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+find_package(ParseArguments)
+find_package(Prereqs)
+find_package(CTargets)
+
 #-----------------------------------------------------------------------
 # Retrieve the current version number
 
@@ -48,8 +53,6 @@ if(GIT_SHA1_RESULT)
     message(FATAL_ERROR
             "Cannot determine git commit: " ${GIT_SHA1_RESULT})
 endif(GIT_SHA1_RESULT)
-
-find_package(PkgConfig)
 
 #-----------------------------------------------------------------------
 # Check for building on Tilera
@@ -110,6 +113,8 @@ endif(CMAKE_C_COMPILER_ID STREQUAL "GNU")
 # Check for prerequisite libraries
 
 find_package(Threads)
+set(THREADS_LDFLAGS "${CMAKE_THREAD_LIBS_INIT}")
+set(THREADS_STATIC_LDFLAGS "${CMAKE_THREAD_LIBS_INIT}")
 
 #-----------------------------------------------------------------------
 # Include our subdirectories

--- a/cmake/FindCTargets.cmake
+++ b/cmake/FindCTargets.cmake
@@ -1,0 +1,215 @@
+# -*- coding: utf-8 -*-
+# ----------------------------------------------------------------------
+# Copyright © 2015, RedJack, LLC.
+# All rights reserved.
+#
+# Please see the COPYING file in this distribution for license details.
+# ----------------------------------------------------------------------
+
+
+#-----------------------------------------------------------------------
+# Configuration options that control all of the below
+
+set(ENABLE_SHARED YES CACHE BOOL "Whether to build a shared library")
+set(ENABLE_SHARED_EXECUTABLES YES CACHE BOOL
+    "Whether to link executables using shared libraries")
+set(ENABLE_STATIC YES CACHE BOOL "Whether to build a static library")
+
+
+#-----------------------------------------------------------------------
+# Library, with options to build both shared and static versions
+
+function(target_add_shared_libraries TARGET_NAME LIBRARIES LOCAL_LIBRARIES)
+    foreach(lib ${LIBRARIES})
+        string(REPLACE "-" "_" lib ${lib})
+        string(TOUPPER ${lib} upperlib)
+        target_link_libraries(
+            ${TARGET_NAME}
+            ${${upperlib}_LDFLAGS}
+        )
+    endforeach(lib)
+    foreach(lib ${LOCAL_LIBRARIES})
+        target_link_libraries(${TARGET_NAME} ${lib}-shared)
+    endforeach(lib)
+endfunction(target_add_shared_libraries)
+
+function(target_add_static_libraries TARGET_NAME LIBRARIES LOCAL_LIBRARIES)
+    foreach(lib ${LIBRARIES})
+        string(REPLACE "-" "_" lib ${lib})
+        string(TOUPPER ${lib} upperlib)
+        target_link_libraries(
+            ${TARGET_NAME}
+            ${${upperlib}_STATIC_LDFLAGS}
+        )
+    endforeach(lib)
+    foreach(lib ${LOCAL_LIBRARIES})
+        target_link_libraries(${TARGET_NAME} ${lib}-static)
+    endforeach(lib)
+endfunction(target_add_static_libraries)
+
+set_property(GLOBAL PROPERTY ALL_LOCAL_LIBRARIES "")
+
+function(add_c_library __TARGET_NAME)
+    set(options)
+    set(one_args OUTPUT_NAME PKGCONFIG_NAME VERSION)
+    set(multi_args LIBRARIES LOCAL_LIBRARIES SOURCES)
+    cmake_parse_arguments(_ "${options}" "${one_args}" "${multi_args}" ${ARGN})
+
+    if (__VERSION MATCHES "^([0-9]+)\\.([0-9]+)\\.([0-9]+)(-dev)?$")
+        set(__VERSION_CURRENT  "${CMAKE_MATCH_1}")
+        set(__VERSION_REVISION "${CMAKE_MATCH_2}")
+        set(__VERSION_AGE      "${CMAKE_MATCH_3}")
+    else (__VERSION MATCHES "^([0-9]+)\\.([0-9]+)\\.([0-9]+)(-dev)?$")
+        message(FATAL_ERROR "Invalid library version number: ${__VERSION}")
+    endif (__VERSION MATCHES "^([0-9]+)\\.([0-9]+)\\.([0-9]+)(-dev)?$")
+
+    math(EXPR __SOVERSION "${__VERSION_CURRENT} - ${__VERSION_AGE}")
+
+    get_property(ALL_LOCAL_LIBRARIES GLOBAL PROPERTY ALL_LOCAL_LIBRARIES)
+    list(APPEND ALL_LOCAL_LIBRARIES ${__TARGET_NAME})
+    set_property(GLOBAL PROPERTY ALL_LOCAL_LIBRARIES "${ALL_LOCAL_LIBRARIES}")
+
+    if (ENABLE_SHARED OR ENABLE_SHARED_EXECUTABLES)
+        add_library(${__TARGET_NAME}-shared SHARED ${__SOURCES})
+        set_target_properties(
+            ${__TARGET_NAME}-shared PROPERTIES
+            OUTPUT_NAME ${__OUTPUT_NAME}
+            CLEAN_DIRECT_OUTPUT 1
+            VERSION ${__VERSION}
+            SOVERSION ${__SOVERSION}
+        )
+
+        if (CMAKE_VERSION VERSION_GREATER "2.8.11")
+            target_include_directories(
+                ${__TARGET_NAME}-shared PUBLIC
+                ${CMAKE_SOURCE_DIR}/include
+                ${CMAKE_BINARY_DIR}/include
+            )
+        else (CMAKE_VERSION VERSION_GREATER "2.8.11")
+            include_directories(
+                ${CMAKE_SOURCE_DIR}/include
+                ${CMAKE_BINARY_DIR}/include
+            )
+        endif (CMAKE_VERSION VERSION_GREATER "2.8.11")
+
+        target_add_shared_libraries(
+            ${__TARGET_NAME}-shared
+            "${__LIBRARIES}"
+            "${__LOCAL_LIBRARIES}"
+        )
+
+        # We have to install the shared library if the user asked us to, or if
+        # the user asked us to link our programs with the shared library.
+        install(TARGETS ${__TARGET_NAME}-shared
+                LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
+    endif (ENABLE_SHARED OR ENABLE_SHARED_EXECUTABLES)
+
+    if (ENABLE_STATIC OR NOT ENABLE_SHARED_EXECUTABLES)
+        add_library(${__TARGET_NAME}-static STATIC ${__SOURCES})
+        set_target_properties(
+            ${__TARGET_NAME}-static PROPERTIES
+            OUTPUT_NAME ${__OUTPUT_NAME}
+            CLEAN_DIRECT_OUTPUT 1
+        )
+
+        if (CMAKE_VERSION VERSION_GREATER "2.8.11")
+            target_include_directories(
+                ${__TARGET_NAME}-static PUBLIC
+                ${CMAKE_SOURCE_DIR}/include
+                ${CMAKE_BINARY_DIR}/include
+            )
+        else (CMAKE_VERSION VERSION_GREATER "2.8.11")
+            include_directories(
+                ${CMAKE_SOURCE_DIR}/include
+                ${CMAKE_BINARY_DIR}/include
+            )
+        endif (CMAKE_VERSION VERSION_GREATER "2.8.11")
+
+        target_add_static_libraries(
+            ${__TARGET_NAME}-static
+            "${__LIBRARIES}"
+            "${__LOCAL_LIBRARIES}"
+        )
+    endif (ENABLE_STATIC OR NOT ENABLE_SHARED_EXECUTABLES)
+
+    if (ENABLE_STATIC)
+        # We DON'T have to install the static library if the user asked us to
+        # link our programs statically.
+        install(TARGETS ${__TARGET_NAME}-static
+                ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+    endif (ENABLE_STATIC)
+
+    set(prefix ${CMAKE_INSTALL_PREFIX})
+    configure_file(
+        ${CMAKE_CURRENT_SOURCE_DIR}/${__PKGCONFIG_NAME}.pc.in
+        ${CMAKE_CURRENT_BINARY_DIR}/${__PKGCONFIG_NAME}.pc
+        @ONLY
+    )
+    install(
+        FILES ${CMAKE_CURRENT_BINARY_DIR}/${__PKGCONFIG_NAME}.pc
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
+    )
+endfunction(add_c_library)
+
+
+#-----------------------------------------------------------------------
+# Executable
+
+function(add_c_executable __TARGET_NAME)
+    set(options SKIP_INSTALL)
+    set(one_args OUTPUT_NAME)
+    set(multi_args LIBRARIES LOCAL_LIBRARIES SOURCES)
+    cmake_parse_arguments(_ "${options}" "${one_args}" "${multi_args}" ${ARGN})
+
+    add_executable(${__TARGET_NAME} ${__SOURCES})
+
+    if (CMAKE_VERSION VERSION_GREATER "2.8.11")
+        target_include_directories(
+            ${__TARGET_NAME} PUBLIC
+            ${CMAKE_SOURCE_DIR}/include
+            ${CMAKE_BINARY_DIR}/include
+        )
+    else (CMAKE_VERSION VERSION_GREATER "2.8.11")
+        include_directories(
+            ${CMAKE_SOURCE_DIR}/include
+            ${CMAKE_BINARY_DIR}/include
+        )
+    endif (CMAKE_VERSION VERSION_GREATER "2.8.11")
+
+    if (ENABLE_SHARED_EXECUTABLES)
+        target_add_shared_libraries(
+            ${__TARGET_NAME}
+            "${__LIBRARIES}"
+            "${__LOCAL_LIBRARIES}"
+        )
+    else (ENABLE_SHARED_EXECUTABLES)
+        target_add_static_libraries(
+            ${__TARGET_NAME}
+            "${__LIBRARIES}"
+            "${__LOCAL_LIBRARIES}"
+        )
+    endif (ENABLE_SHARED_EXECUTABLES)
+
+    if (NOT __SKIP_INSTALL)
+        install(TARGETS ${__TARGET_NAME} RUNTIME DESTINATION bin)
+    endif (NOT __SKIP_INSTALL)
+endfunction(add_c_executable)
+
+
+#-----------------------------------------------------------------------
+# Test case
+
+pkgconfig_prereq(check OPTIONAL)
+
+function(add_c_test TEST_NAME)
+    get_property(ALL_LOCAL_LIBRARIES GLOBAL PROPERTY ALL_LOCAL_LIBRARIES)
+    add_c_executable(
+        ${TEST_NAME}
+        SKIP_INSTALL
+        OUTPUT_NAME ${TEST_NAME}
+        SOURCES ${TEST_NAME}.c
+        LIBRARIES check
+        LOCAL_LIBRARIES ${ALL_LOCAL_LIBRARIES}
+    )
+    add_test(${TEST_NAME} ${TEST_NAME})
+endfunction(add_c_test)

--- a/cmake/FindParseArguments.cmake
+++ b/cmake/FindParseArguments.cmake
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+# ----------------------------------------------------------------------
+# Copyright © 2015, RedJack, LLC.
+# All rights reserved.
+#
+# Please see the COPYING file in this distribution for license details.
+# ----------------------------------------------------------------------
+
+
+# CMake 2.8.4 and higher gives us cmake_parse_arguments out of the box.  For
+# earlier versions (RHEL5!) we have to define it ourselves.  (The definition
+# comes from <http://www.cmake.org/Wiki/CMakeMacroParseArguments>.)
+
+if (CMAKE_VERSION VERSION_LESS "2.8.4")
+
+MACRO(CMAKE_PARSE_ARGUMENTS prefix arg_names option_names)
+  SET(DEFAULT_ARGS)
+  FOREACH(arg_name ${arg_names})
+    SET(${prefix}_${arg_name})
+  ENDFOREACH(arg_name)
+  FOREACH(option ${option_names})
+    SET(${prefix}_${option} FALSE)
+  ENDFOREACH(option)
+
+  SET(current_arg_name DEFAULT_ARGS)
+  SET(current_arg_list)
+  FOREACH(arg ${ARGN})
+    SET(larg_names ${arg_names})
+    LIST(FIND larg_names "${arg}" is_arg_name)
+    IF (is_arg_name GREATER -1)
+      SET(${prefix}_${current_arg_name} ${current_arg_list})
+      SET(current_arg_name ${arg})
+      SET(current_arg_list)
+    ELSE (is_arg_name GREATER -1)
+      SET(loption_names ${option_names})
+      LIST(FIND loption_names "${arg}" is_option)
+      IF (is_option GREATER -1)
+          SET(${prefix}_${arg} TRUE)
+      ELSE (is_option GREATER -1)
+          SET(current_arg_list ${current_arg_list} ${arg})
+      ENDIF (is_option GREATER -1)
+    ENDIF (is_arg_name GREATER -1)
+  ENDFOREACH(arg)
+  SET(${prefix}_${current_arg_name} ${current_arg_list})
+ENDMACRO(CMAKE_PARSE_ARGUMENTS)
+
+else (CMAKE_VERSION VERSION_LESS "2.8.4")
+
+    include(CMakeParseArguments)
+
+endif (CMAKE_VERSION VERSION_LESS "2.8.4")

--- a/cmake/FindPrereqs.cmake
+++ b/cmake/FindPrereqs.cmake
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+# ----------------------------------------------------------------------
+# Copyright © 2015, RedJack, LLC.
+# All rights reserved.
+#
+# Please see the COPYING file in this distribution for license details.
+# ----------------------------------------------------------------------
+
+
+#-----------------------------------------------------------------------
+# Configuration options that control all of the below
+
+set(PKG_CONFIG_PATH CACHE STRING "pkg-config search path")
+if (PKG_CONFIG_PATH)
+    set(ENV{PKG_CONFIG_PATH} "${PKG_CONFIG_PATH}:$ENV{PKG_CONFIG_PATH}")
+endif (PKG_CONFIG_PATH)
+
+
+#-----------------------------------------------------------------------
+# pkg-config prerequisites
+
+find_package(PkgConfig)
+
+function(pkgconfig_prereq DEP)
+    set(options OPTIONAL)
+    set(one_args)
+    set(multi_args)
+    cmake_parse_arguments(_ "${options}" "${one_args}" "${multi_args}" ${ARGN})
+
+    string(REGEX REPLACE "[<>=].*" "" SHORT_NAME "${DEP}")
+    string(REPLACE "-" "_" SHORT_NAME "${SHORT_NAME}")
+    string(TOUPPER ${SHORT_NAME} UPPER_SHORT_NAME)
+    string(TOLOWER ${SHORT_NAME} LOWER_SHORT_NAME)
+
+    set(USE_CUSTOM_${UPPER_SHORT_NAME} NO CACHE BOOL
+        "Whether you want to provide custom details for ${LOWER_SHORT_NAME}")
+
+    if (NOT USE_CUSTOM_${UPPER_SHORT_NAME})
+        set(PKG_CHECK_ARGS)
+        if (NOT __OPTIONAL)
+            list(APPEND PKG_CHECK_ARGS REQUIRED)
+        endif (NOT __OPTIONAL)
+        list(APPEND PKG_CHECK_ARGS ${DEP})
+
+        pkg_check_modules(${UPPER_SHORT_NAME} ${PKG_CHECK_ARGS})
+    endif (NOT USE_CUSTOM_${UPPER_SHORT_NAME})
+
+    include_directories(${${UPPER_SHORT_NAME}_INCLUDE_DIRS})
+    link_directories(${${UPPER_SHORT_NAME}_LIBRARY_DIRS})
+endfunction(pkgconfig_prereq)
+
+
+#-----------------------------------------------------------------------
+# find_library prerequisites
+
+function(library_prereq LIB_NAME)
+    set(options OPTIONAL)
+    set(one_args)
+    set(multi_args)
+    cmake_parse_arguments(_ "${options}" "${one_args}" "${multi_args}" ${ARGN})
+
+    string(REPLACE "-" "_" SHORT_NAME "${LIB_NAME}")
+    string(TOUPPER ${SHORT_NAME} UPPER_SHORT_NAME)
+    string(TOLOWER ${SHORT_NAME} LOWER_SHORT_NAME)
+
+    set(USE_CUSTOM_${UPPER_SHORT_NAME} NO CACHE BOOL
+        "Whether you want to provide custom details for ${LOWER_SHORT_NAME}")
+
+    if (USE_CUSTOM_${UPPER_SHORT_NAME})
+        include_directories(${${UPPER_SHORT_NAME}_INCLUDE_DIRS})
+        link_directories(${${UPPER_SHORT_NAME}_LIBRARY_DIRS})
+    else (USE_CUSTOM_${UPPER_SHORT_NAME})
+        find_library(${UPPER_SHORT_NAME}_LIBRARIES ${LIB_NAME})
+    endif (USE_CUSTOM_${UPPER_SHORT_NAME})
+
+endfunction(library_prereq)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,43 +6,11 @@
 # Please see the COPYING file in this distribution for license details.
 # ----------------------------------------------------------------------
 
-include_directories(${CMAKE_SOURCE_DIR}/include)
-include_directories(${CMAKE_BINARY_DIR}/include)
-
 #-----------------------------------------------------------------------
-# Build the library
+# libcork
 
-set(LIBCORK_SRC
-    libcork/cli/commands.c
-    libcork/core/allocator.c
-    libcork/core/error.c
-    libcork/core/gc.c
-    libcork/core/hash.c
-    libcork/core/ip-address.c
-    libcork/core/mempool.c
-    libcork/core/timestamp.c
-    libcork/core/u128.c
-    libcork/core/version.c
-    libcork/ds/array.c
-    libcork/ds/bitset.c
-    libcork/ds/buffer.c
-    libcork/ds/dllist.c
-    libcork/ds/file-stream.c
-    libcork/ds/hash-table.c
-    libcork/ds/managed-buffer.c
-    libcork/ds/ring-buffer.c
-    libcork/ds/slice.c
-    libcork/posix/directory-walker.c
-    libcork/posix/env.c
-    libcork/posix/exec.c
-    libcork/posix/files.c
-    libcork/posix/process.c
-    libcork/posix/subprocess.c
-    libcork/pthreads/thread.c
-)
-
-# Update the VERSION and SOVERSION properties below according to the following
-# rules (taken from [1]):
+# Update the VERSION property below according to the following rules (taken from
+# [1]):
 #
 # VERSION = current.revision.age
 #
@@ -59,86 +27,89 @@ set(LIBCORK_SRC
 #   6. If any interfaces have been removed or changed since the last public
 #      release, then set `age` to 0.
 #
-# SOVERSION should always equal `current-age`.
-#
 # Note that changing `current` means that you are releasing a new
 # backwards-incompatible version of the library.  This has implications on
-# packaging, so once an API has stabilized, these should be a rare occurrence.
+# packaging, so once an API has stabilized, this should be a rare occurrence.
 #
 # [1] http://www.gnu.org/software/libtool/manual/html_node/Updating-version-info.html#Updating-version-info
 
-if (ENABLE_SHARED OR ENABLE_SHARED_EXECUTABLES)
-    add_library(libcork SHARED ${LIBCORK_SRC})
-    target_link_libraries(libcork ${CMAKE_THREAD_LIBS_INIT})
-    set_target_properties(libcork PROPERTIES
-        OUTPUT_NAME cork
-        COMPILE_DEFINITIONS CORK_API=CORK_EXPORT
-        CLEAN_DIRECT_OUTPUT 1
-        VERSION 15.3.0
-        SOVERSION 15
-    )
+add_c_library(
+    libcork
+    OUTPUT_NAME cork
+    PKGCONFIG_NAME libcork
+    VERSION 15.3.0
+    SOURCES
+        libcork/cli/commands.c
+        libcork/core/allocator.c
+        libcork/core/error.c
+        libcork/core/gc.c
+        libcork/core/hash.c
+        libcork/core/ip-address.c
+        libcork/core/mempool.c
+        libcork/core/timestamp.c
+        libcork/core/u128.c
+        libcork/core/version.c
+        libcork/ds/array.c
+        libcork/ds/bitset.c
+        libcork/ds/buffer.c
+        libcork/ds/dllist.c
+        libcork/ds/file-stream.c
+        libcork/ds/hash-table.c
+        libcork/ds/managed-buffer.c
+        libcork/ds/ring-buffer.c
+        libcork/ds/slice.c
+        libcork/posix/directory-walker.c
+        libcork/posix/env.c
+        libcork/posix/exec.c
+        libcork/posix/files.c
+        libcork/posix/process.c
+        libcork/posix/subprocess.c
+        libcork/pthreads/thread.c
+    LIBRARIES
+        threads
+)
 
-    # We have to install the shared library if the user asked us to, or if the
-    # user asked us to link our programs with the shared library.
-    install(TARGETS libcork LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
+if (ENABLE_SHARED OR ENABLE_SHARED_EXECUTABLES)
+    set_target_properties(libcork-shared PROPERTIES
+        COMPILE_DEFINITIONS CORK_API=CORK_EXPORT
+    )
 endif (ENABLE_SHARED OR ENABLE_SHARED_EXECUTABLES)
 
-#-----------------------------------------------------------------------
-# Build a static library to simulate embedding libcork
-
 if (ENABLE_STATIC OR NOT ENABLE_SHARED_EXECUTABLES)
-    add_library(libcork-static STATIC ${LIBCORK_SRC})
-    target_link_libraries(libcork-static ${CMAKE_THREAD_LIBS_INIT})
     set_target_properties(libcork-static PROPERTIES
-        OUTPUT_NAME cork
         COMPILE_DEFINITIONS CORK_API=CORK_LOCAL
-        CLEAN_DIRECT_OUTPUT 1
     )
 endif (ENABLE_STATIC OR NOT ENABLE_SHARED_EXECUTABLES)
 
-if (ENABLE_STATIC)
-    # We DON'T have to install the static library if the user asked us to link
-    # our programs statically.
-    install(TARGETS libcork-static ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
-endif (ENABLE_STATIC)
 
 #-----------------------------------------------------------------------
 # Utility commands
 
-set(CORK_HASH_SRC cork-hash/cork-hash.c)
-add_executable(cork-hash ${CORK_HASH_SRC})
-if (ENABLE_SHARED_EXECUTABLES)
-    target_link_libraries(cork-hash libcork)
-else (ENABLE_SHARED_EXECUTABLES)
-    target_link_libraries(cork-hash libcork-static)
-endif (ENABLE_SHARED_EXECUTABLES)
-
-install(TARGETS cork-hash RUNTIME DESTINATION bin)
-
-set(CORK_INITIALIZER_SRC
-    cork-initializer/init1.c
-    cork-initializer/init2.c
-    cork-initializer/main.c
+add_c_executable(
+    cork-hash
+    OUTPUT_NAME cork-hash
+    SOURCES cork-hash/cork-hash.c
+    LOCAL_LIBRARIES
+        libcork
 )
-add_executable(cork-initializer ${CORK_INITIALIZER_SRC})
-if (ENABLE_SHARED_EXECUTABLES)
-    target_link_libraries(cork-initializer libcork)
-else (ENABLE_SHARED_EXECUTABLES)
-    target_link_libraries(cork-initializer libcork-static)
-endif (ENABLE_SHARED_EXECUTABLES)
 
-set(CORK_TEST_SRC cork-test/cork-test.c)
-add_executable(cork-test ${CORK_TEST_SRC})
-if (ENABLE_SHARED_EXECUTABLES)
-    target_link_libraries(cork-test libcork)
-else (ENABLE_SHARED_EXECUTABLES)
-    target_link_libraries(cork-test libcork-static)
-endif (ENABLE_SHARED_EXECUTABLES)
+add_c_executable(
+    cork-initializer
+    SKIP_INSTALL
+    OUTPUT_NAME cork-initializer
+    SOURCES
+        cork-initializer/init1.c
+        cork-initializer/init2.c
+        cork-initializer/main.c
+    LOCAL_LIBRARIES
+        libcork
+)
 
-#-----------------------------------------------------------------------
-# Generate the pkg-config file
-
-set(prefix ${CMAKE_INSTALL_PREFIX})
-configure_file(libcork.pc.in ${CMAKE_CURRENT_BINARY_DIR}/libcork.pc @ONLY)
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libcork.pc
-        DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+add_c_executable(
+    cork-test
+    SKIP_INSTALL
+    OUTPUT_NAME cork-test
+    SOURCES cork-test/cork-test.c
+    LOCAL_LIBRARIES
+        libcork
+)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,23 +1,15 @@
 # -*- coding: utf-8 -*-
 # ----------------------------------------------------------------------
-# Copyright © 2011-2014, RedJack, LLC.
+# Copyright © 2011-2015, RedJack, LLC.
 # All rights reserved.
 #
 # Please see the COPYING file in this distribution for license details.
 # ----------------------------------------------------------------------
 
-include_directories(${CMAKE_SOURCE_DIR}/include)
-include_directories(${CMAKE_BINARY_DIR}/include)
-link_directories(${CMAKE_CURRENT_BINARY_DIR}/../src)
-
-#-----------------------------------------------------------------------
-# Check for prerequisite libraries
-
-find_package(PkgConfig)
-
-pkg_check_modules(CHECK REQUIRED check)
-include_directories(${CHECK_INCLUDE_DIRS})
-link_directories(${CHECK_LIBRARY_DIRS})
+include_directories(
+    ${CMAKE_SOURCE_DIR}/include
+    ${CMAKE_BINARY_DIR}/include
+)
 
 #-----------------------------------------------------------------------
 # Build the test cases
@@ -33,7 +25,7 @@ macro(make_test test_name)
     if (ENABLE_SHARED OR ENABLE_SHARED_EXECUTABLES)
         add_executable(shared-${test_name} ${test_name}.c)
         target_link_libraries(shared-${test_name} ${CHECK_LIBRARIES}
-            libcork)
+            libcork-shared)
         add_test(shared-${test_name} shared-${test_name})
     endif (ENABLE_SHARED OR ENABLE_SHARED_EXECUTABLES)
 


### PR DESCRIPTION
The C template now provides helper macros that define all of our cmake rules for building libraries and executables.  This patch updates our build scripts to use them.