### PR TITLE
Debug allocator should always abort

### DIFF
--- a/src/libcork/core/allocator.c
+++ b/src/libcork/core/allocator.c
@@ -403,7 +403,11 @@ cork_debug_alloc__free(const struct cork_alloc *alloc, void *ptr,
     size_t  *base = ((size_t *) ptr) - 1;
     size_t  actual_size = *base;
     size_t  real_size = actual_size + sizeof(size_t);
-    assert(actual_size == expected_size);
+    if (CORK_UNLIKELY(actual_size != expected_size)) {
+        cork_abort
+            ("Incorrect size when freeing pointer (got %zu, expected %zu)",
+             expected_size, actual_size);
+    }
     cork_alloc_free(alloc->parent, base, real_size);
 }
 


### PR DESCRIPTION
We provide a "debug" allocator, which verifies that the sizes that you provide to the allocation functions matches the sizes that you provide to the deallocation functions.  Before, we used the builtin `assert` macro to perform this check.  However, that means that if we compile libcork in `Release` mode (in which asserts are left out), we never actually perform the check!  We now use an explicit check, and call `abort` ourselves if the check fails — our assumption being that if you ask for the debug allocator, you want at least this particular bit of debug behavior even if the rest of the library was compiled in `Release` mode.