### PR TITLE
Higher timeout for bitset tests

### DIFF
--- a/tests/test-bitset.c
+++ b/tests/test-bitset.c
@@ -79,6 +79,7 @@ test_suite()
     Suite  *s = suite_create("bits");
 
     TCase  *tc_ds = tcase_create("bits");
+    tcase_set_timeout(tc_ds, 20.0);
     tcase_add_test(tc_ds, test_bitset);
     suite_add_tcase(s, tc_ds);
 


### PR DESCRIPTION
This test can take awhile, which sometimes causes a spurious test failure when running under Travis.  Let's bump the timeout to give us more wiggle room.