### PR TITLE
Separate callback functions for cork_mempool

### DIFF
--- a/docs/old/mempool.rst
+++ b/docs/old/mempool.rst
@@ -126,7 +126,9 @@ instance, we might as well try to reuse the memory for the
 ``scratch_space`` field, as well.  To do this, you provide initialization and
 finalization callbacks:
 
-.. function:: void cork_mempool_set_callbacks(struct cork_mempool \*mp, void \*user_data, cork_free_f free_user_data, cork_init_f init_object, cork_done_f done_object)
+.. function:: void cork_mempool_set_user_data(struct cork_mempool \*mp, void \*user_data, cork_free_f free_user_data)
+              void cork_mempool_set_init_object(struct cork_mempool \*mp, cork_init_f init_object)
+              void cork_mempool_set_done_object(struct cork_mempool \*mp, cork_done_f done_object)
 
    Provide callback functions that will be used to initialize and finalize each
    object created by the memory pool.
@@ -152,7 +154,8 @@ logic goes into ``done_object``, and not our destructor::
 
     static cork_mempool  *pool;
     pool = cork_mempool_new(pool, struct my_data);
-    cork_mempool_set_callbacks(pool, NULL, NULL, my_data_init, my_data_done);
+    cork_mempool_set_init_object(pool, my_data_init);
+    cork_mempool_set_done_object(pool, my_data_done);
 
     struct my_data *
     my_data_new(void)

--- a/include/libcork/core/mempool.h
+++ b/include/libcork/core/mempool.h
@@ -42,6 +42,18 @@ cork_mempool_free(struct cork_mempool *mp);
 
 
 CORK_API void
+cork_mempool_set_user_data(struct cork_mempool *mp,
+                           void *user_data, cork_free_f free_user_data);
+
+CORK_API void
+cork_mempool_set_init_object(struct cork_mempool *mp, cork_init_f init_object);
+
+CORK_API void
+cork_mempool_set_done_object(struct cork_mempool *mp, cork_done_f done_object);
+
+/* Deprecated; you should now use separate calls to cork_mempool_set_user_data,
+ * cork_mempool_set_init_object, and cork_mempool_set_done_object. */
+CORK_API void
 cork_mempool_set_callbacks(struct cork_mempool *mp,
                            void *user_data, cork_free_f free_user_data,
                            cork_init_f init_object,

--- a/src/libcork/core/mempool.c
+++ b/src/libcork/core/mempool.c
@@ -108,16 +108,35 @@ cork_mempool_free(struct cork_mempool *mp)
 
 
 void
+cork_mempool_set_user_data(struct cork_mempool *mp,
+                           void *user_data, cork_free_f free_user_data)
+{
+    cork_free_user_data(mp);
+    mp->user_data = user_data;
+    mp->free_user_data = free_user_data;
+}
+
+void
+cork_mempool_set_init_object(struct cork_mempool *mp, cork_init_f init_object)
+{
+    mp->init_object = init_object;
+}
+
+void
+cork_mempool_set_done_object(struct cork_mempool *mp, cork_done_f done_object)
+{
+    mp->done_object = done_object;
+}
+
+void
 cork_mempool_set_callbacks(struct cork_mempool *mp,
                            void *user_data, cork_free_f free_user_data,
                            cork_init_f init_object,
                            cork_done_f done_object)
 {
-    cork_free_user_data(mp);
-    mp->user_data = user_data;
-    mp->free_user_data = free_user_data;
-    mp->init_object = init_object;
-    mp->done_object = done_object;
+    cork_mempool_set_user_data(mp, user_data, free_user_data);
+    cork_mempool_set_init_object(mp, init_object);
+    cork_mempool_set_done_object(mp, done_object);
 }
 
 

--- a/tests/test-mempool.c
+++ b/tests/test-mempool.c
@@ -100,8 +100,9 @@ START_TEST(test_mempool_reuse_01)
     size_t  done_call_count = 0;
     struct cork_mempool  *mp;
     mp = cork_mempool_new_ex(int64_t, BLOCK_SIZE);
-    cork_mempool_set_callbacks
-        (mp, &done_call_count, NULL, int64_init, int64_done);
+    cork_mempool_set_user_data(mp, &done_call_count, NULL);
+    cork_mempool_set_init_object(mp, int64_init);
+    cork_mempool_set_done_object(mp, int64_done);
 
     int64_t  *obj;
     fail_if((obj = cork_mempool_new_object(mp)) == NULL,


### PR DESCRIPTION
The cork_mempool type lets you provide `init_object` and `done_object` callbacks, which are called when an instance is first allocated and finally deallocated (i.e., exactly once per instance, regardless of how many times the instance is reused).  This patch updates the API to have separate functions for setting each of those callbacks, instead of the single big function — this is more consistent with our current pattern, and is nicer for ABI compatibility reasons.

The existing `set_callbacks` function still exists, but it's now deprecated and no longer mentioned in the documentation.